### PR TITLE
feat(operator-metrics):OperatorにPrometheusメトリクスを導入

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 
 	grpcv1alpha1 "github.com/shtsukada/grpc-burner-operator/api/v1alpha1"
 	"github.com/shtsukada/grpc-burner-operator/internal/controller"
+	"github.com/shtsukada/grpc-burner-operator/internal/metrics"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -200,6 +201,8 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	metrics.RegisterCustomMetrics()
 
 	if err := (&controller.GrpcBurnerReconciler{
 		Client: mgr.GetClient(),

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: stsukada/grpc-burner-operator
   newTag: latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,40 +5,9 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - burner.grpc-demo.dev
-  resources:
-  - burnerjobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - burner.grpc-demo.dev
-  resources:
-  - burnerjobs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
   - grpc.burner.dev
   resources:
+  - burnerjobs
   - grpcburners
   - observabilityconfigs
   verbs:
@@ -52,6 +21,7 @@ rules:
 - apiGroups:
   - grpc.burner.dev
   resources:
+  - burnerjobs/finalizers
   - grpcburners/finalizers
   - observabilityconfigs/finalizers
   verbs:
@@ -59,6 +29,7 @@ rules:
 - apiGroups:
   - grpc.burner.dev
   resources:
+  - burnerjobs/status
   - grpcburners/status
   - observabilityconfigs/status
   verbs:

--- a/config/samples/grpc_v1alpha1_grpcburner.yaml
+++ b/config/samples/grpc_v1alpha1_grpcburner.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  mode: unary
+  mode: "unary"
   messageSize: 512
   qps: 100
   duration: "5m"

--- a/internal/controller/burnerjob_controller.go
+++ b/internal/controller/burnerjob_controller.go
@@ -25,9 +25,9 @@ type BurnerJobReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=burner.grpc-demo.dev,resources=burnerjobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=burner.grpc-demo.dev,resources=burnerjobs/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=grpc.burner.dev,resources=burnerjobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=grpc.burner.dev,resources=burnerjobs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=grpc.burner.dev,resources=burnerjobs/finalizers,verbs=update
 
 func (r *BurnerJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("burnerjob", req.NamespacedName)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,27 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	ReconcileTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "grpcburner_operator_reconcile_total",
+			Help: "Total number of reconciliations performed",
+		},
+		[]string{"controller"},
+	)
+
+	ReconcileErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "grpcburner_operator_reconcile_errors_total",
+			Help: "Total number of reconciliation errors",
+		},
+		[]string{"controller"},
+	)
+)
+
+func RegisterCustomMetrics() {
+	prometheus.MustRegister(ReconcileTotal, ReconcileErrors)
+}


### PR DESCRIPTION
## 概要
OperatorへPrometheusメトリクス出力機能を追加しました。
これによりOperatorの動作状況(Reconcile回数、エラー回数)をPrometheusで可視化。

## 変更点
- internal/metrics/metrics.goを新規作成、カスタムメトリクスを定義
  - grpcburner_operator_reconcile_total
  - grpcburner_operator_reconcile_errors_total
- cmd/main.go に RegisterCustomMetrics()を追加し、起動時にメトリクスを登録
- grpcburner_controller.go 内に .Inc() を追加し、Reconcile回数とエラー数を記録
