### PR TITLE
feat(helm-otelcollector):OpenTelemetry Collector導入（Helm）＋Grafana Tempoデータソース追加

### DIFF
--- a/config/monitoring/grafana/loki-datasource-configmap.yaml
+++ b/config/monitoring/grafana/loki-datasource-configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource-loki
+  namespace: monitoring
+  labels:
+    grafana_datasource: "1"
+data:
+  loki-datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        uid: loki
+        type: loki
+        access: proxy
+        url: http://loki.monitoring.svc.cluster.local:3100
+        isDefault: false
+        jsonData:
+          httpMethod: GET
+          derivedFields:
+            - name: trace_id
+              matcherRegex: '"trace_id":"([a-f0-9-]+)"'
+              datasourceUid: tempo
+              url: ${__tempo_base_url}/trace/${__match_1}
+            - name: traceId
+              matcherRegex: '"traceId":"([a-f0-9-]+)"'
+              datasourceUid: tempo
+              url: ${__tempo_base_url}/trace/${__match_1}

--- a/config/monitoring/grafana/loki-datasource.yaml
+++ b/config/monitoring/grafana/loki-datasource.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki.monitoring.svc.cluster.local:3100
+    isDefault: false
+    jsonData:
+      httpMethod: GET
+      derivedFields:
+        - name: trace_id
+          matcherRegex: '"trace_id":"([a-f0-9-]+)"'
+          datasourceUid: tempo
+          url: ${__tempo_base_url}/trace/${__match_1}
+        - name: traceId
+          matcherRegex: '"traceId":"([a-f0-9-]+)"'
+          datasourceUid: tempo
+          url: ${__tempo_base_url}/trace/${__match_1}

--- a/config/monitoring/grafana/tempo-datasource-configmap.yaml
+++ b/config/monitoring/grafana/tempo-datasource-configmap.yaml
@@ -6,14 +6,31 @@ metadata:
   labels:
     grafana_datasource: "1"
 data:
-  tempo-datasource.yaml: |
+  tempo-datasource.yaml: |-
     apiVersion: 1
     datasources:
       - name: Tempo
+        uid: tempo
         type: tempo
         access: proxy
-        orgId: 1
         url: http://tempo.monitoring.svc.cluster.local:3100
+        basicAuth: false
         isDefault: false
-        version: 1
-        editable: true
+        jsonData:
+          httpMethod: GET
+          tracesToLogs:
+            datasourceUid: loki
+            tags: ["pod", "namespace"]
+            mappedTags:
+              - key: "service.name"
+                value: "service"
+            spanStartTimeShift: "-1h"
+            spanEndTimeShift: "1h"
+            filterByTraceID: true
+            filterBySpanID: false
+          derivedFields:
+            - name: trace_id
+              matcherRegex: "trace_id\":\"(\\w+)\"
+              datasourceUid: tempo
+              url: "$${__value.raw}"
+              urlDisplayLabel: "View Trace"

--- a/config/monitoring/kube-prometheus-stack/values.yaml
+++ b/config/monitoring/kube-prometheus-stack/values.yaml
@@ -2,7 +2,7 @@ grafana:
   service:
     type: LoadBalancer
   persistence:
-    enabled: true
+    enabled: false
     storageClassName: standard
     accessModes:
       - ReadWriteOnce

--- a/config/monitoring/loki-stack/values.yaml
+++ b/config/monitoring/loki-stack/values.yaml
@@ -1,6 +1,6 @@
 loki:
   persistence:
-    enabled: true
+    enabled: false
     storageClassName: standard
     size: 10Gi
 

--- a/config/prometheus/monitor_otelcollector.yaml
+++ b/config/prometheus/monitor_otelcollector.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: otelcollector
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otelcollector
+  namespaceSelector:
+    matchNames: ["monitoring"]
+  endpoints:
+    - port: metrics
+      interval: 15s

--- a/config/rbac/otelcollector-k8sattributes-rbac.yaml
+++ b/config/rbac/otelcollector-k8sattributes-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otelcollector-k8sattributes
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otelcollector-k8sattributes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otelcollector-k8sattributes
+subjects:
+  - kind: ServiceAccount
+    name: otelcollector-opentelemetry-collector
+    namespace: monitoring

--- a/infra/helm/otel-collector/values.yaml
+++ b/infra/helm/otel-collector/values.yaml
@@ -1,0 +1,123 @@
+mode: deployment
+
+ports:
+  otlp:
+    enabled: true
+    containerPort: 4317
+    servicePort: 4317
+    protocol: TCP
+  otlp-http:
+    enabled: true
+    containerPort: 4318
+    servicePort: 4318
+    protocol: TCP
+  metrics:
+    enabled: true
+    containerPort: 8889
+    servicePort: 8889
+    protocol: TCP
+
+service:
+  type: ClusterIP
+
+serviceMonitor:
+  enabled: true
+
+image:
+  repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  tag: 0.110.0
+  pullPolicy: IfNotPresent
+
+config:
+  receivers:
+    filelog:
+      include:
+        - /var/log/pods/*/*/*.log
+      exclude:
+        - /var/log/pods/monitoring_otelcollector-opentelemetry-collector*/opentelemetry-collector/*.log
+      start_at: beginning
+      operators:
+        - type: json_parser
+          if: 'body matches "^\\s*\\{"'
+          parse_from: body
+          on_error: drop
+    otlp:
+      protocols:
+        grpc: {}
+        http: {}
+
+  processors:
+    batch: {}
+    resourcedetection:
+      detectors: [env, system, k8snode]
+      timeout: 2s
+      override: false
+
+    k8sattributes:
+      auth_type: serviceAccount
+      extract:
+        metadata:
+          - k8s.pod.name
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.uid
+          - k8s.deployment.name
+
+  exporters:
+    prometheus:
+      endpoint: "0.0.0.0:8889"
+    logging:
+      loglevel: info
+    otlp:
+      endpoint: tempo.monitoring.svc.cluster.local:4317
+      tls:
+        insecure: true
+    loki:
+      endpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+      default_labels_enabled:
+        resource: true
+        attributes: true
+      tls:
+        insecure: true
+
+  service:
+    telemetry:
+      metrics:
+        address: 0.0.0.0:8888
+    pipelines:
+      metrics:
+        receivers: [otlp]
+        processors: [batch, resourcedetection, k8sattributes]
+        exporters: [prometheus, logging]
+      logs:
+        receivers: [filelog, otlp]
+        processors: [batch, resourcedetection, k8sattributes]
+        exporters: [loki, logging]
+      traces:
+        receivers: [otlp]
+        processors: [batch, resourcedetection, k8sattributes]
+        exporters: [otlp, logging]
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+extraVolumes:
+  - name: varlogpods
+    hostPath:
+      path: /var/log/pods
+      type: Directory
+extraVolumeMounts:
+  - name: varlogpods
+    mountPath: /var/log/pods
+    readOnly: true
+
+extraEnvs:
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName

--- a/infra/terraform/eks/main.tf
+++ b/infra/terraform/eks/main.tf
@@ -1,16 +1,16 @@
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
   version = "5.1.0"
 
   name = var.cluster_name
   cidr = var.vpc_cidr
 
-  azs = var.azs
+  azs             = var.azs
   private_subnets = var.private_subnets
-  public_subnets = var.public_subnets
+  public_subnets  = var.public_subnets
 
-  enable_nat_gateway = true
-  single_nat_gateway = true
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
   enable_dns_hostnames = true
 }
 
@@ -18,19 +18,19 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 19.21"
 
-  cluster_name = var.cluster_name
-  cluster_version = "1.29"
-  subnet_ids = module.vpc.private_subnets
-  vpc_id = module.vpc.vpc_id
-  cluster_endpoint_public_access  = true
-  enable_irsa = false
+  cluster_name                   = var.cluster_name
+  cluster_version                = "1.29"
+  subnet_ids                     = module.vpc.private_subnets
+  vpc_id                         = module.vpc.vpc_id
+  cluster_endpoint_public_access = true
+  enable_irsa                    = false
 
   eks_managed_node_groups = {
     default = {
       instance_types = ["t3.medium"]
-      min_size = 1
-      max_size = 3
-      desired_size = 2
+      min_size       = 1
+      max_size       = 3
+      desired_size   = 2
     }
   }
 }

--- a/infra/terraform/eks/outputs.tf
+++ b/infra/terraform/eks/outputs.tf
@@ -1,19 +1,19 @@
 output "cluster_name" {
   description = "EKS cluster name"
-  value = module.eks.cluster_name
+  value       = module.eks.cluster_name
 }
 
 output "cluster_endpoint" {
   description = "Endpoint for EKS control plane"
-  value = module.eks.cluster_endpoint
+  value       = module.eks.cluster_endpoint
 }
 
 output "cluster_security_group_id" {
   description = "Security group ID attached to the cluster"
-  value = module.eks.cluster_security_group_id
+  value       = module.eks.cluster_security_group_id
 }
 
 output "vpc_id" {
   description = "VPC ID"
-  value = module.vpc.vpc_id
+  value       = module.vpc.vpc_id
 }

--- a/infra/terraform/eks/provider.tf
+++ b/infra/terraform/eks/provider.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 5.0"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
       version = "2.22.0"
     }
   }

--- a/infra/terraform/eks/variables.tf
+++ b/infra/terraform/eks/variables.tf
@@ -1,39 +1,39 @@
 variable "region" {
   description = "AWS region"
-  default = "ap-northeast-1"
+  default     = "ap-northeast-1"
 }
 
 variable "cluster_name" {
   description = "EKS Cluster name"
-  default = "grpc-observability-cluster"
+  default     = "grpc-observability-cluster"
 }
 
 variable "vpc_cidr" {
   description = "CIDR block for the VPC"
-  default = "10.0.0.0/16"
+  default     = "10.0.0.0/16"
 }
 
 variable "azs" {
   description = "Availability Zones"
-  default = ["ap-northeast-1a", "ap-northeast-1c"]
+  default     = ["ap-northeast-1a", "ap-northeast-1c"]
 }
 
 variable "public_subnets" {
   description = "Public Subnets"
-  default = ["10.0.101.0/24", "10.0.102.0/24"]
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
 }
 
 variable "private_subnets" {
   description = "Private Subnets"
-  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
 }
 
 variable "aws_auth_users" {
   description = "List of IAM users to add to aws-auth configmap"
   type = list(object({
-    userarn = string
+    userarn  = string
     username = string
-    groups = list(string)
+    groups   = list(string)
   }))
   default = []
 }

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -9,6 +9,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -37,4 +39,16 @@ func InitTracer(ctx context.Context) (*sdktrace.TracerProvider, error) {
 
 	otel.SetTracerProvider(tp)
 	return tp, nil
+}
+
+func TracerLogger(ctx context.Context, baseLogger *zap.Logger) *zap.Logger {
+	spanCtx := trace.SpanContextFromContext(ctx)
+	if !spanCtx.IsValid() {
+		return baseLogger
+	}
+
+	return baseLogger.With(
+		zap.String("trace_id", spanCtx.SpanID().String()),
+		zap.String("span_id", spanCtx.SpanID().String()),
+	)
 }


### PR DESCRIPTION
## 概要
- OpenTelemetry CollectorをHelm Chartで導入
- GrafanaにTempoデータソースを追加し、Lokiログからトレースへのジャンプ、およびトレースからログへの参照を可能にしました

## 主な変更点
- otelcolのHelm Chart values.yamlを追加・設定
- Tempoデータソース設定をkube-prometheus-stackのvalues.yamlに追加
- tracesToLogs / tracesToMetricsのマッピング設定を追加
- Helm upgradeによりGrafanaへ自動反映

<img width="1176" height="738" alt="スクリーンショット 2025-08-12 20 30 16" src="https://github.com/user-attachments/assets/b7198463-a214-4247-8cfe-852b8891f4f2" />

