### PR TITLE
feat(argocd-integration):Argo CD App-of-Apps構成と各Applicationの同基準制御を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,20 @@ Kubernetes上でgRPC負荷生成とObservability統合を行うためのカス�
 
 ## 概要
 `grpc-burner-operator`はカスタムリソース(CRD)を通じてKubernetes上でgRPCサーバと負荷生成Podを動的に管理します。将来的にObservabilityの統合やGitOps連携も実装します。
+
+
+
+## 運用メモ
+
+- 本構成はArgo CDにより、`App-of-Apps`パターンでgRPCアプリ/監視スタック/Otel Collectorを順序適用します。
+- 適用順は`sync-wave`により制御：
+  - Wave -2 : monitoring-stack(Prometheus/Loki/Tempo)
+  - Wave -1 : otel-collector(外部Helmチャート、自リポジトリvalues)
+  - Wave  0 : grpc-burner(Operator、gRPCアプリ)
+- 適用手順：
+  1. Argo CD が稼働しているクラスタに `project.yaml` を適用
+  2. `app-of-apps.yaml` を適用（子Applicationが自動登録・同期）
+  ```bash
+  kubectl apply -n argocd -f deploy/argocd/project.yaml
+  kubectl apply -n argocd -f deploy/argocd/app-of-apps.yaml
+  ```

--- a/deploy/argocd/app-of-apps.yaml
+++ b/deploy/argocd/app-of-apps.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grpc-portfolio
+  namespace: argocd
+spec:
+  project: grpc-burner
+  source:
+    repoURL: https://github.com/shtsukada/grpc-burner-operator.git
+    targetRevision: main
+    path: deploy/argocd/apps
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/deploy/argocd/apps/app-grpc.yaml
+++ b/deploy/argocd/apps/app-grpc.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grpc-burner
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: grpc-burner
+  source:
+    repoURL: https://github.com/shtsukada/grpc-burner-operator.git
+    targetRevision: main
+    path: config/default
+    kustomize: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: grpc-burner-operator-system
+  revisionHistoryLimit: 5
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 2m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/deploy/argocd/apps/app-monitoring.yaml
+++ b/deploy/argocd/apps/app-monitoring.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: monitoring-stack
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  project: grpc-burner
+  sources:
+    - repoURL: https://github.com/shtsukada/grpc-burner-operator.git
+      targetRevision: main
+      path: config/monitoring
+      kustomize: {}
+    - repoURL: https://github.com/shtsukada/grpc-burner-operator.git
+      targetRevision: main
+      path: config/prometheus
+      kustomize: {}
+    - repoURL: https://github.com/shtsukada/grpc-burner-operator.git
+      targetRevision: main
+      path: config/network-policy
+      kustomize: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  revisionHistoryLimit: 5
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 2m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/deploy/argocd/apps/app-otelcol.yaml
+++ b/deploy/argocd/apps/app-otelcol.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: otel-collector
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  project: grpc-burner
+  sources:
+    - repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
+      chart: opentelemetry-collector
+      targetRevision: 0.102.0
+      helm:
+        valueFiles:
+          - $values/infra/helm/otel-collector/values.yaml
+    - repoURL: https://github.com/shtsukada/grpc-burner-operator.git
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  revisionHistoryLimit: 5
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 2m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/deploy/argocd/project.yaml
+++ b/deploy/argocd/project.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: grpc-burner
+  namespace: argocd
+spec:
+  description: Project for grpc-burner-operator and monitoring stack
+  destinations:
+    - namespace: grpc-app
+      server: https://kubernetes.default.svc
+    - namespace: monitoring
+      server: https://kubernetes.default.svc
+    - namespace: argocd
+      server: https://kubernetes.default.svc
+  sourceRepos:
+    - https://github.com/shtsukada/grpc-burner-operator.git
+    - https://open-telemetry.github.io/opentelemetry-helm-charts
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'

--- a/deploy/argocd/system/argocd-cm.yaml
+++ b/deploy/argocd/system/argocd-cm.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  resource.customizations: |
+    apiextensions.k8s.io/CustomResourceDefinition:
+      ignoreDifferences: |
+        jqPathExpressions:
+        - .spec.conversion?.webhook?.clientConfig?.caBundle
+
+        jsonPointers:
+        - /metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration
+
+        managedFieldsManagers:
+        - kube-controller-manager
+        - kubectl-client-side-apply

--- a/infra/helm/otel-collector/values.yaml
+++ b/infra/helm/otel-collector/values.yaml
@@ -19,9 +19,11 @@ ports:
 
 service:
   type: ClusterIP
+  labels:
+    app.kubernetes.io/name: otelcollector
 
 serviceMonitor:
-  enabled: true
+  enabled: false
 
 image:
   repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib


### PR DESCRIPTION
## 概要
- Argo CDにApp-of-Appsパターンを導入し、gRPCアプリ/監視スタック/Otel Collectorを順序制御付きでデプロイ可能にしました。

## 主な変更点
- `deploy/argocd/project.yaml`を追加し、必要なsourceRepos(自リポジトリ、Otel Helmリポジトリ)を許可
- `deploy/argocd/app-of-apps.yaml`を追加し、子Applicationの一括管理を実装
- `deploy/argocd/apps/`はいかに3つの子Applicationを作成
  - app-monitoring.yaml（Wave -2）
  - app-otelcol.yaml（Wave -1）
  - app-grpc.yaml（Wave 0）
- 各Applicationに `sync-wave` と `retry` オプションを設定し、安定同期を実現
- README.mdに適用手順を追記